### PR TITLE
Add scripts for the go relayer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init: kill-dev
 	@echo "Initializing both blockchains..."
 	./network/init.sh
 	./network/start.sh
-	@echo "Initializing relayer..." 
+	@echo "Initializing hermes relayer..."
 	./network/hermes/restore-keys.sh
 	./network/hermes/create-conn.sh
 
@@ -18,4 +18,16 @@ start-rly:
 kill-dev:
 	@echo "Killing icad and removing previous data"
 	-@rm -rf ./data
+	-@rm -rf ./network/relayer/config/
 	-@killall simd 2>/dev/null
+
+init-go-relayer: kill-dev
+	@echo "Initializing both blockchains..."
+	./network/init.sh
+	./network/start.sh
+	@echo "Initializing go-relayer..."
+	./network/relayer/setup-relayer.sh
+	./network/relayer/create-path.sh
+
+start-go-rly:
+	./network/relayer/start.sh

--- a/network/hermes/restore-keys.sh
+++ b/network/hermes/restore-keys.sh
@@ -5,10 +5,11 @@ set -e
 . ./network/hermes/variables.sh
 
 ### Sleep is needed otherwise the relayer crashes when trying to init
-sleep 1s
+sleep 1
+
 ### Restore Keys
 $HERMES_BINARY -c ./network/hermes/config.toml keys restore test-1 -m "alley afraid soup fall idea toss can goose become valve initial strong forward bright dish figure check leopard decide warfare hub unusual join cart"
-sleep 5s
+sleep 5
 
 $HERMES_BINARY -c ./network/hermes/config.toml keys restore test-2 -m "record gift you once hip style during joke field prize dust unique length more pencil transfer quit train device arrive energy sort steak upset"
-sleep 5s
+sleep 5

--- a/network/relayer/chains/test-1.json
+++ b/network/relayer/chains/test-1.json
@@ -1,0 +1,16 @@
+{
+  "type": "cosmos",
+  "value": {
+    "key": "testkey",
+    "chain-id": "test-1",
+    "rpc-addr": "http://127.0.0.1:16657",
+    "account-prefix": "cosmos",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.2,
+    "gas-prices": "0.01stake",
+    "debug": true,
+    "timeout": "20s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/network/relayer/chains/test-2.json
+++ b/network/relayer/chains/test-2.json
@@ -1,0 +1,16 @@
+{
+  "type": "cosmos",
+  "value": {
+    "key": "testkey",
+    "chain-id": "test-2",
+    "rpc-addr": "http://127.0.0.1:26657",
+    "account-prefix": "cosmos",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.2,
+    "gas-prices": "0.01stake",
+    "debug": true,
+    "timeout": "20s",
+    "output-format": "json",
+    "sign-mode": "direct"
+  }
+}

--- a/network/relayer/create-path.sh
+++ b/network/relayer/create-path.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Load shell variables
+. ./network/relayer/variables.sh
+
+### Configure the clients and connection
+echo "Initiating client & connection handshake..."
+$RELAYER_BINARY tx connection "$PATH_NAME" --home "$RELAYER_CONFIG_DIR" -d
+
+sleep 5
+
+# Initiate a handshake for a new fee enabled transfer channel using the existing connection
+echo "Initiating channel handshake..."
+$RELAYER_BINARY tx channel $PATH_NAME --src-port transfer --dst-port transfer --version "{\"fee_version\":\"fee29-1\",\"app_version\":\"ics20-1\"}" --home "$RELAYER_CONFIG_DIR" -d
+
+sleep 5
+
+# At this point the chains are running, the relayer is configured, and we have created a path between both chains,
+# including a new channel that has support for fee incentives.

--- a/network/relayer/setup-relayer.sh
+++ b/network/relayer/setup-relayer.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Load shell variables
+. ./network/relayer/variables.sh
+
+### Init the config file
+$RELAYER_BINARY config init --home "$RELAYER_CONFIG_DIR"
+
+### Add the chain configs
+$RELAYER_BINARY chains add --file $RELAYER_DIRECTORY/chains/"$CHAIN1".json --home "$RELAYER_CONFIG_DIR"
+$RELAYER_BINARY chains add --file $RELAYER_DIRECTORY/chains/"$CHAIN2".json --home "$RELAYER_CONFIG_DIR"
+
+### Restore keys
+$RELAYER_BINARY keys restore "$CHAIN1" "$KEY1" "alley afraid soup fall idea toss can goose become valve initial strong forward bright dish figure check leopard decide warfare hub unusual join cart" --home "$RELAYER_CONFIG_DIR"
+$RELAYER_BINARY keys restore "$CHAIN2" "$KEY2" "record gift you once hip style during joke field prize dust unique length more pencil transfer quit train device arrive energy sort steak upset" --home "$RELAYER_CONFIG_DIR"
+
+### Create a new path in config file
+$RELAYER_BINARY paths new "$CHAIN1" "$CHAIN2" "$PATH_NAME" --home "$RELAYER_CONFIG_DIR"

--- a/network/relayer/start.sh
+++ b/network/relayer/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Load shell variables
+. ./network/relayer/variables.sh
+
+# Start the relayer
+echo "Starting relayer..."
+
+$RELAYER_BINARY start "$PATH_NAME" --home "$RELAYER_CONFIG_DIR" -d

--- a/network/relayer/variables.sh
+++ b/network/relayer/variables.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+RELAYER_BINARY=rly
+RELAYER_DIRECTORY=./network/relayer
+RELAYER_CONFIG_DIR=./network/relayer/config
+PATH_NAME=test1-test2
+CHAIN1=test-1
+CHAIN2=test-2
+KEY1=testkey
+KEY2=testkey


### PR DESCRIPTION
I was running through the [testing docs](https://hackmd.io/0qHkPDIVSZWhhK8QdKLfCQ?view) for fee middleware and ended up building off the test scripts provided in your repo for the go-relayer. I figured I would open up a PR in case it's desirable to have them upstream also.
