### PR TITLE
Updated Hermes CLI to be compatible with Hermes v1.0.0

### DIFF
--- a/network/hermes/config.toml
+++ b/network/hermes/config.toml
@@ -101,7 +101,7 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 3000000
 gas_price = { price = 0.001, denom = 'stake' }
-gas_adjustment = 0.1
+gas_multiplier = 1.1
 max_msg_num = 30
 max_tx_size = 2097152
 clock_drift = '5s'
@@ -122,7 +122,7 @@ store_prefix = 'ibc'
 default_gas = 100000
 max_gas = 3000000
 gas_price = { price = 0.001, denom = 'stake' }
-gas_adjustment = 0.1
+gas_multiplier = 1.1
 max_msg_num = 30
 max_tx_size = 2097152
 clock_drift = '5s'

--- a/network/hermes/create-conn.sh
+++ b/network/hermes/create-conn.sh
@@ -6,6 +6,6 @@ set -e
 
 ### Configure the clients and connection
 echo "Initiating connection handshake..."
-$HERMES_BINARY -c $CONFIG_DIR create connection test-1 test-2
+$HERMES_BINARY --config $CONFIG_DIR create connection --a-chain test-1 --b-chain test-2
 
 sleep 2

--- a/network/hermes/relayer1_mnemonic
+++ b/network/hermes/relayer1_mnemonic
@@ -1,0 +1,1 @@
+alley afraid soup fall idea toss can goose become valve initial strong forward bright dish figure check leopard decide warfare hub unusual join cart

--- a/network/hermes/relayer2_mnemonic
+++ b/network/hermes/relayer2_mnemonic
@@ -1,0 +1,1 @@
+record gift you once hip style during joke field prize dust unique length more pencil transfer quit train device arrive energy sort steak upset

--- a/network/hermes/restore-keys.sh
+++ b/network/hermes/restore-keys.sh
@@ -7,9 +7,16 @@ set -e
 ### Sleep is needed otherwise the relayer crashes when trying to init
 sleep 1
 
-### Restore Keys
-$HERMES_BINARY -c ./network/hermes/config.toml keys restore test-1 -m "alley afraid soup fall idea toss can goose become valve initial strong forward bright dish figure check leopard decide warfare hub unusual join cart"
+### Restore Keys for chain test-1
+$HERMES_BINARY --config ./network/hermes/config.toml keys add --chain test-1 --mnemonic-file network/hermes/relayer1_mnemonic
+sleep 5
+$HERMES_BINARY --config ./network/hermes/config.toml keys add --chain test-1 --mnemonic-file network/hermes/wallet1_mnemonic --key-name wallet1
+sleep 5
+$HERMES_BINARY --config ./network/hermes/config.toml keys add --chain test-1 --mnemonic-file network/hermes/wallet2_mnemonic --key-name wallet2
 sleep 5
 
-$HERMES_BINARY -c ./network/hermes/config.toml keys restore test-2 -m "record gift you once hip style during joke field prize dust unique length more pencil transfer quit train device arrive energy sort steak upset"
+### Restore Keys for chain test-2
+$HERMES_BINARY --config ./network/hermes/config.toml keys add --chain test-2 --mnemonic-file network/hermes/relayer2_mnemonic
+sleep 5
+$HERMES_BINARY --config ./network/hermes/config.toml keys add --chain test-2 --mnemonic-file network/hermes/wallet3_mnemonic --key-name wallet3
 sleep 5

--- a/network/hermes/start.sh
+++ b/network/hermes/start.sh
@@ -5,4 +5,4 @@
 
 # Start the hermes relayer in multi-paths mode
 echo "Starting hermes relayer..."
-$HERMES_BINARY -c $CONFIG_DIR start
+$HERMES_BINARY --config $CONFIG_DIR start

--- a/network/hermes/wallet1_mnemonic
+++ b/network/hermes/wallet1_mnemonic
@@ -1,0 +1,1 @@
+banner spread envelope side kite person disagree path silver will brother under couch edit food venture squirrel civil budget number acquire point work mass

--- a/network/hermes/wallet2_mnemonic
+++ b/network/hermes/wallet2_mnemonic
@@ -1,0 +1,1 @@
+veteran try aware erosion drink dance decade comic dawn museum release episode original list ability owner size tuition surface ceiling depth seminar capable only

--- a/network/hermes/wallet3_mnemonic
+++ b/network/hermes/wallet3_mnemonic
@@ -1,0 +1,1 @@
+vacuum burst ordinary enact leaf rabbit gather lend left chase park action dish danger green jeans lucky dish mesh language collect acquire waste load


### PR DESCRIPTION
Hermes `v1.0.0` has introduced some breaking changes:

* All the commands only take long flags, e.g. `-c` has been replaced with `--config`
* A flag is required before every argument, e.g. `hermes create connection test-1 test-2` is now `hermes create connection --a-chain test-1 --b-chain test-2`
* The command `hermes keys restore` has been replaced with `hermes keys add`
* The command `hermes keys add` doesn't take the mnemonic input as a string, but now takes a file containing the mnemonic as input
* The configuration `gas_adjustment` has been replaced with `gas_multiplier`, which directly multiplies the gas estimate by its value. E.g. with a value of `1.1` the gas is increased by `10%`